### PR TITLE
Adding rosjava templates and missing android template to the setup.py in...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ d = generate_distutils_setup(
             ],
     package_data = {'rosjava_build_tools': [
            'templates/android_package/*',
+           'templates/android_project/*',
+           'templates/rosjava_msg_project/*',
+           'templates/rosjava_package/*',
+           'templates/rosjava_project/*',
            'templates/init_repo/*',
         ]},
     requires=['rospy' 'rospkg']


### PR DESCRIPTION
...stall script.

The current setup.py script do not install rosjava_\* templates which prevents catkin_rosjava_create\* scripts from working!
This fix add the missing templates.
