### PR TITLE
Master

### DIFF
--- a/src/rosjava_build_tools/templates/android_package/build.gradle.in
+++ b/src/rosjava_build_tools/templates/android_package/build.gradle.in
@@ -27,6 +27,7 @@ buildscript {
                 url p
             }
         }
+        mavenCentral()
         mavenLocal()
         maven {
             url rosMavenRepository

--- a/src/rosjava_build_tools/templates/android_package/build.gradle.in
+++ b/src/rosjava_build_tools/templates/android_package/build.gradle.in
@@ -19,23 +19,7 @@ task wrapper(type: Wrapper) {
 }
 
 buildscript {
-    def rosMavenPath = "$System.env.ROS_MAVEN_PATH".split(':').collect { 'file://' + it }
-    def rosMavenRepository = "$System.env.ROS_MAVEN_REPOSITORY"
-    repositories {
-        rosMavenPath.each { p ->
-            maven {
-                url p
-            }
-        }
-        mavenCentral()
-        mavenLocal()
-        maven {
-            url rosMavenRepository
-        }
-    }
-    dependencies {
-        classpath group: 'org.ros.rosjava_bootstrap', name: 'gradle_plugins', version: '[0.2,0.3)'
-    }
+   apply from: "https://github.com/rosjava/rosjava_bootstrap/raw/indigo/buildscript.gradle"
 }
 
 apply plugin: 'catkin'


### PR DESCRIPTION
While trying to create a new android pkg with this very basic command example:

catkin_create_android_pkg android_foo android_apps android_extras rosjava_core

I found this error:

FAILURE: Build failed with an exception.
- What went wrong:
  A problem occurred configuring root project 'android_foo'.

> Could not resolve all dependencies for configuration ':classpath'.
> Could not find org.codehaus.groovy:groovy-all:2.2.0.
>      Required by:
>          :android_foo:unspecified > org.ros.rosjava_bootstrap:gradle_plugins:0.2.0

As Daniel suggested I changed the buildscript section to use the rosjava (not android) indigo stacks one.
