### PR TITLE
Fix for genjava ignoring most packages in standalone mode

### DIFF
--- a/src/rosjava_build_tools/catkin.py
+++ b/src/rosjava_build_tools/catkin.py
@@ -52,6 +52,8 @@ def index_message_package_dependencies_from_local_environment(package_name_list=
     # i.e. no duplicates!
     for path in reversed(package_paths):
         for package_path, package in catkin_pkg.packages.find_packages(path).items():
+            # resolve and normalize absolute path because it is used as a key below
+            package_path = os.path.normpath(os.path.join(path, package_path))
             all_packages[package.name] = (package_path, package)
             if has_build_depend_on_message_generation(package) or package.name in message_package_whitelist:
                 if package_name_list:


### PR DESCRIPTION
The genjava_message_artifacts tool in package genjava calls `rosjava_build_tools.catkin.index_message_package_dependencies_from_local_environment()` to generate a list of all message packages and their dependencies in topological order from the list of  package names given in the command line.

Especially in cases where `ROS_PACKAGE_PATH` lists the package paths for each individual package separately, which is the case in isolated builds using `catkin_make_isolated` or `catkin_tools`, the relative path returned by [catkin_pkg.packages.find_packages()](http://docs.ros.org/independent/api/catkin_pkg/catkin_pkg.html#catkin_pkg.packages.find_package_paths) is only `"."`. In general, the relative package path is not unique, but it is used as key of a dictionary when passed to `topological_order_packages` a few lines below. As a consequence, all packages but one of each group that have the same relative package path were missing in the returned list and hence no artifacts were generated by genjava_message_artifacts, which eventually resulted in missing dependency errors.

This patch adds a line that transforms the relative to the absolute package path, avoiding the above problem.

This bug affects the command line (3.1) and meta message package (3.3) approaches explained at http://wiki.ros.org/rosjava/Tutorials/indigo/RosJava%20Message%20Artifacts. It has no consequences for most users because genjava already generated the artifacts before the meta message package is built, but if the automatic generation is disabled via the `ROS_LANG_DISABLE` variable or the target package is located in an underlay devel-space without genjava, the meta message package built is likely to fail. [rosjava_messages](https://github.com/rosjava/rosjava_messages) or the ROS build farm are not affected because they use the installed versions of the message packages, where the relative path inside `/opt/ros/xxx/share` is unique.

Example output without this patch:
```cmake
Scanning dependencies of target sdw_behavior_msgdeps_generate_artifacts                                                                                                                                                                
[100%] Compiling rosjava message artifacts for [roscpp std_msgs dynamic_reconfigure sdw_common_msgs sdw_world_msgs sdw_hal_msgs]                                                                                                       
                                                                                                                                                                                                                                       
Generating message artifacts for:                                                                                                                                                                                                      
['std_msgs', 'roscpp', 'dynamic_reconfigure', 'sdw_world_msgs']                                                                                                                                                                        
warning: [options] bootstrap class path not set in conjunction with -source 1.7                                                                                                                                                        
1 warning                                                                                                                                                                                                                              
Uploading: org/ros/rosjava_messages/std_msgs/0.5.11/std_msgs-0.5.11.jar to repository remote at file:/opt/sdw/devel/share/maven/                                                                                                       
Transferring 15K from remote                                                                                                                                                                                                           
Uploaded 15K                                                                                                                                                                                                                           
warning: [options] bootstrap class path not set in conjunction with -source 1.7                                                                                                                                                        
1 warning                                                                                                                                                                                                                              
Uploading: org/ros/rosjava_messages/roscpp/1.12.7/roscpp-1.12.7.jar to repository remote at file:/opt/sdw/devel/share/maven/                                                                                                           
Transferring 4K from remote                                                                                                                                                                                                            
Uploaded 4K                                                                                                                                                                                                                            
warning: [options] bootstrap class path not set in conjunction with -source 1.7                                                                                                                                                        
1 warning                                                                                                                                                                                                                              
Uploading: org/ros/rosjava_messages/dynamic_reconfigure/1.5.48/dynamic_reconfigure-1.5.48.jar to repository remote at file:/opt/sdw/devel/share/maven/                                                                                 
Transferring 7K from remote                                                                                                                                                                                                            
Uploaded 7K                                                                                                                                                                                                                            
                                                                                                                                                                                                                                       
FAILURE: Build failed with an exception.                                                                                                                                                                                               
                                                                                                                                                                                                                                       
* What went wrong:                                                                                                                                                                                                                     
Could not resolve all dependencies for configuration ':runtime'.                                                                                                                                                                       
> Could not find org.ros.rosjava_messages:sdw_common_msgs:0.0.4.                                                                                                                                                                       
  Searched in the following locations:
  Searched in the following locations:                                                                                                                                                                                                 
      file:/opt/sdw/devel/share/maven/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                                         
      file:/opt/sdw/devel/share/maven/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                                         
      file:/opt/ros/kinetic/share/maven/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                                       
      file:/opt/ros/kinetic/share/maven/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                                       
      https://github.com/rosjava/rosjava_mvn_repo/raw/master/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                  
      https://github.com/rosjava/rosjava_mvn_repo/raw/master/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                  
      file:/home/johannes/.m2/repository/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                                      
      file:/home/johannes/.m2/repository/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                                      
      http://repository.springsource.com/maven/bundles/release/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                
      http://repository.springsource.com/maven/bundles/release/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                
      http://repository.springsource.com/maven/bundles/external/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                               
      http://repository.springsource.com/maven/bundles/external/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                               
      https://jcenter.bintray.com/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.pom                                                                                                                             
      https://jcenter.bintray.com/org/ros/rosjava_messages/sdw_common_msgs/0.0.4/sdw_common_msgs-0.0.4.jar                                                                                                                             
  Required by:                                                                                                                                                                                                                         
      org.ros.rosjava_messages:sdw_world_msgs:0.0.6   
```

As you can see, `sdw_common_msgs` and `sdw_hal_msgs` are missing in the second line of the genjava_message_artifacts output, but `sdw_world_msgs` depends on `sdw_common_msgs`.

I would appreciate a bugfix release into ROS kinetic to fix our CI jobs without workaround.