### PR TITLE
respect read-only source space

### DIFF
--- a/cmake/rosjava.cmake.em
+++ b/cmake/rosjava.cmake.em
@@ -84,10 +84,11 @@ macro(catkin_rosjava_setup)
     ###################################
     # Execution
     ###################################
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME} ALL
         #COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} "env" "|" "grep" "ROS" 
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} ${gradle_tasks}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
         VERBATIM
         COMMENT "Gradling tasks for ${PROJECT_NAME}"
     )
@@ -108,9 +109,10 @@ macro(catkin_rosjava_setup)
     if(NOT TARGET gradle-clean)
         add_custom_target(gradle-clean)
     endif()
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-clean-${PROJECT_NAME}
         COMMAND ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} clean
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
         COMMENT "Cleaning gradle project for ${PROJECT_NAME}"
     )
     add_dependencies(gradle-clean gradle-clean-${PROJECT_NAME})
@@ -130,10 +132,11 @@ macro(catkin_android_setup)
     else()
       set(gradle_tasks ${ARGV})
     endif()
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME}
         ALL
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_tasks}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
         VERBATIM
     )
     catkin_package_xml()
@@ -146,9 +149,10 @@ macro(catkin_android_setup)
     if(NOT TARGET gradle-clean)
         add_custom_target(gradle-clean)
     endif()
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-clean-${PROJECT_NAME}
         COMMAND ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} clean
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     )
     add_dependencies(gradle-clean gradle-clean-${PROJECT_NAME})
 endmacro()

--- a/cmake/rosjava.cmake.em
+++ b/cmake/rosjava.cmake.em
@@ -87,7 +87,7 @@ macro(catkin_rosjava_setup)
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME} ALL
         #COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} "env" "|" "grep" "ROS" 
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} --project-dir ${CMAKE_CURRENT_SOURCE_DIR}  --project-cache-dir ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/.gradle -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
         VERBATIM
         COMMENT "Gradling tasks for ${PROJECT_NAME}"
@@ -135,7 +135,7 @@ macro(catkin_android_setup)
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME}
         ALL
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} --project-cache-dir ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/.gradle -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
         VERBATIM
     )

--- a/cmake/rosjava.cmake.em
+++ b/cmake/rosjava.cmake.em
@@ -84,11 +84,10 @@ macro(catkin_rosjava_setup)
     ###################################
     # Execution
     ###################################
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME} ALL
         #COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} "env" "|" "grep" "ROS" 
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} --project-dir ${CMAKE_CURRENT_SOURCE_DIR}  --project-cache-dir ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/.gradle -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} ${gradle_options} --project-dir ${CMAKE_CURRENT_SOURCE_DIR}  --project-cache-dir ${PROJECT_BINARY_DIR}/.gradle -PbuildDir=${PROJECT_BINARY_DIR} ${gradle_tasks}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         VERBATIM
         COMMENT "Gradling tasks for ${PROJECT_NAME}"
     )
@@ -109,10 +108,9 @@ macro(catkin_rosjava_setup)
     if(NOT TARGET gradle-clean)
         add_custom_target(gradle-clean)
     endif()
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-clean-${PROJECT_NAME}
         COMMAND ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} clean
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         COMMENT "Cleaning gradle project for ${PROJECT_NAME}"
     )
     add_dependencies(gradle-clean gradle-clean-${PROJECT_NAME})
@@ -132,11 +130,10 @@ macro(catkin_android_setup)
     else()
       set(gradle_tasks ${ARGV})
     endif()
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-${PROJECT_NAME}
         ALL
-        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} --project-cache-dir ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/.gradle -PbuildDir=${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src ${gradle_tasks}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
+        COMMAND ${ROSJAVA_ENV} ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} --project-dir ${CMAKE_CURRENT_SOURCE_DIR} --project-cache-dir ${PROJECT_BINARY_DIR}/.gradle -PbuildDir=${PROJECT_BINARY_DIR} ${gradle_tasks}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         VERBATIM
     )
     catkin_package_xml()
@@ -149,10 +146,9 @@ macro(catkin_android_setup)
     if(NOT TARGET gradle-clean)
         add_custom_target(gradle-clean)
     endif()
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src)
     add_custom_target(gradle-clean-${PROJECT_NAME}
         COMMAND ${CATKIN_ENV} ${${PROJECT_NAME}_gradle_BINARY} clean
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     )
     add_dependencies(gradle-clean gradle-clean-${PROJECT_NAME})
 endmacro()

--- a/generate_environment_variables.py
+++ b/generate_environment_variables.py
@@ -45,8 +45,12 @@ if __name__ == '__main__':
         repo = get_environment_variable(environment_variables, 'ROS_MAVEN_DEPLOYMENT_REPOSITORY')
         if repo is None:
             repo = os.path.join(workspaces[0], 'share', 'maven')
-        else:
+        else: #ROS_MAVEN_DEPLOYMENT_REPOSITORY is already set
             if repo in [os.path.join(w, 'share', 'maven') for w in workspaces]:
+                # ROS_MAVEN_DEPLOYMENT_REPOSITORY is part of workspace chain
+                pass
+            else:
+                # ROS_MAVEN_DEPLOYMENT_REPOSITORY is NOT part of workspace chain, set to top-most workspace
                 repo = os.path.join(workspaces[0], 'share', 'maven')
         print(repo)
     elif args.maven_repository:


### PR DESCRIPTION
by executing the custom_targets in the build space rather than source space

read-only source space is enforced by e.g. https://github.com/ros-industrial/industrial_ci