### PR TITLE
preserve ros maven deployment repository

### DIFF
--- a/generate_environment_variables.py
+++ b/generate_environment_variables.py
@@ -45,8 +45,12 @@ if __name__ == '__main__':
         repo = get_environment_variable(environment_variables, 'ROS_MAVEN_DEPLOYMENT_REPOSITORY')
         if repo is None:
             repo = os.path.join(workspaces[0], 'share', 'maven')
-        else:
+        else: #ROS_MAVEN_DEPLOYMENT_REPOSITORY is already set
             if repo in [os.path.join(w, 'share', 'maven') for w in workspaces]:
+                # ROS_MAVEN_DEPLOYMENT_REPOSITORY is part of workspace chain
+                pass
+            else:
+                # ROS_MAVEN_DEPLOYMENT_REPOSITORY is NOT part of workspace chain, set to top-most workspace
                 repo = os.path.join(workspaces[0], 'share', 'maven')
         print(repo)
     elif args.maven_repository:


### PR DESCRIPTION
includes #37 
i.e. essentially this PR is about https://github.com/rosjava/rosjava_build_tools/pull/38/commits/4da3ba6ae140e9eda2529bc5a397737dbb94ffbd

I was facing problems where my rosjava packages where part of a chained workspace, i.e.:
`CMAKE_PREFIX_PATH` something like `wsA/devel:wsB/devel:/opt/ros/kinetic`

my rosjava packages are located in `wsB/src`
if I `catkin build`my chain bottom-up and then finally source the top-most `wsA/devel/setup.bash`, `ROS_MAVEN_DEPLOYMENT_REPOSITORY` will be set to `wsA/devel/share/maven`

when re-compiling my rosjava packages in `wsB`, now some of them fail
(in particular the action message generation part)
they have been compiling successfully while `ROS_MAVEN_DEPLOYMENT_REPOSITORY` has been set to `wsA/devel/share/maven`

this commit preserves the the environment variable `ROS_MAVEN_DEPLOYMENT_REPOSITORY` if it has been set (by user or by the first rosjava_build_tools envhook) and the set value is part of `CMAKE_PREFIX_PATH`


did anybody experience a similar issue when using rosjava packages with chained workspaces?
I don't know what has been the intention behind alway setting `ROS_MAVEN_DEPLOYMENT_REPOSITORY` to the top-most workspace[0]